### PR TITLE
Lint for redundant `throws` or `returns`

### DIFF
--- a/Documentation/Explainers/E013.md
+++ b/Documentation/Explainers/E013.md
@@ -1,0 +1,24 @@
+## E013: Redundant docstring for `throws` or `returns`
+
+
+Function signature does not throw yet a docstring for throw is present. Or,
+function doesn't return anything yet a docstring for return is present.
+
+
+### Bad
+
+```swift
+/// Description
+/// - parameter foo: description for foo
+/// - throws: throws some things?
+/// - returns: returns otherthings?
+func f(foo: Int)
+```
+
+### Good
+
+```swift
+/// Description
+/// - parameter foo: description for foo
+func f(foo: Int)
+```

--- a/Sources/Critic/DocProblem.swift
+++ b/Sources/Critic/DocProblem.swift
@@ -24,6 +24,7 @@ public struct DocProblem {
         case keywordCasing(String, String) // Actual, expected
         case descriptionShouldEndWithEmptyLine
         case sectionShouldEndWithEmptyLine(String) // keyword or parameter name
+        case redundantKeyword(String) // keyword
 
         public var explainerID: String {
             switch self {
@@ -51,6 +52,8 @@ public struct DocProblem {
                 return "E011"
             case .descriptionShouldEndWithEmptyLine, .sectionShouldEndWithEmptyLine:
                 return "E012"
+            case .redundantKeyword:
+                return "E013"
             }
         }
     }

--- a/Sources/DrString/check.swift
+++ b/Sources/DrString/check.swift
@@ -37,7 +37,7 @@ public let checkCommand = Command(
         queue.async {
             do {
                 for documentable in try extractDocs(fromSourcePath: path).compactMap({ $0 }) {
-                    for problem in try validate(documentable, ignoreThrows: ignoreThrows, firstLetterUpper: firstLetterUpper, needsSeparation: config.options.separatedSections) {
+                    if let problem = try validate(documentable, ignoreThrows: ignoreThrows, firstLetterUpper: firstLetterUpper, needsSeparation: config.options.separatedSections) {
                         problemCount += problem.details.count
                         let output: String
                         switch (format, IsTerminal.standardOutput) {

--- a/Sources/Informant/PlainTextFormatter.swift
+++ b/Sources/Informant/PlainTextFormatter.swift
@@ -35,6 +35,8 @@ private extension DocProblem.Detail {
             return "Overall description should end with an empty line"
         case .sectionShouldEndWithEmptyLine(let keywordOrName):
             return "`\(keywordOrName)`'s description should end with an empty line"
+        case .redundantKeyword(let keyword):
+            return "Redundant documentation for `\(keyword)`"
         }
     }
 

--- a/Sources/Informant/TtyTextFormatter.swift
+++ b/Sources/Informant/TtyTextFormatter.swift
@@ -36,6 +36,8 @@ private extension DocProblem.Detail {
             return "Overall description should end with an empty line"
         case .sectionShouldEndWithEmptyLine(let keywordOrName):
             return "\(keywordOrName, color: .green)'s description should end with an empty line"
+        case .redundantKeyword(let keyword):
+            return "Redundant documentation for \(keyword, color: .green)"
         }
     }
 

--- a/Tests/DrStringTests/DrStringTests.swift
+++ b/Tests/DrStringTests/DrStringTests.swift
@@ -75,4 +75,8 @@ final class DrStringTests: XCTestCase {
         XCTAssert(runTest(fileName: "missingSectionSeparator", expectEmpty: false,
                           needsSeparation: Section.allCases))
     }
+
+    func testRedundantKeywords() throws {
+        XCTAssert(runTest(fileName: "redundantKeywords", expectEmpty: false))
+    }
 }

--- a/Tests/DrStringTests/Fixtures/redundantKeywords.swift
+++ b/Tests/DrStringTests/Fixtures/redundantKeywords.swift
@@ -1,0 +1,27 @@
+// CHECK: Redundant documentation for `throws`
+/// description
+/// - parameter a: description for a
+/// - throws: wat
+/// - returns: zero
+func redundantKeywords0(a: Int) -> Int { 0 }
+
+// CHECK: Redundant documentation for `returns`
+/// description
+/// - parameter a: description for a
+/// - throws: wat
+/// - returns: zero
+func redundantKeywords1(a: Int) throws {}
+
+// CHECK: Redundant documentation for `throws`
+// CHECK: Redundant documentation for `returns`
+/// description
+/// - parameter a: description for a
+/// - throws: wat
+/// - returns: zero
+func redundantKeywords2(a: Int) {}
+
+// CHECK: Redundant documentation for `returns`
+/// description
+/// - parameter a: description for a
+/// - returns: zero
+func redundantKeywords3(a: Int) {}

--- a/Tests/DrStringTests/XCTestManifests.swift
+++ b/Tests/DrStringTests/XCTestManifests.swift
@@ -16,6 +16,7 @@ extension DrStringTests {
         ("testMissingSectionSeparator", testMissingSectionSeparator),
         ("testMissingStuff", testMissingStuff),
         ("testNoDocNoError", testNoDocNoError),
+        ("testRedundantKeywords", testRedundantKeywords),
         ("testUppercaseKeywords", testUppercaseKeywords),
     ]
 }


### PR DESCRIPTION
Closes #26