### PR TITLE
[Informant] Improve whitespace formatting

### DIFF
--- a/Sources/Informant/PlainTextFormatter.swift
+++ b/Sources/Informant/PlainTextFormatter.swift
@@ -1,6 +1,10 @@
 import Critic
 
 private extension DocProblem.Detail {
+    private func actualWhitespace(_ actual: String) -> String {
+        actual.isEmpty ? "none" : "`\(actual)`"
+    }
+
     private var description: String {
         switch self {
         case .redundantParameter(let name):
@@ -14,19 +18,19 @@ private extension DocProblem.Detail {
         case .preDashSpaceInParameter(let expected, let actual, let name):
             return "Parameter `\(name)` should start with exactly \(expected) space\(expected > 1 ? "s" : "") before `-`, found `\(actual)`"
         case .spaceBetweenDashAndParamaterKeyword(let actual, let keyword, let name):
-            return "`\(name)` should have exactly 1 space between `-` and `\(keyword)`, found `\(actual)`"
+            return "`\(name)` should have exactly 1 space between `-` and `\(keyword)`, found `\(actualWhitespace(actual))`"
         case .spaceBeforeParameterName(let actual, let keyword, let name):
-            return "There should be exactly 1 space between `\(keyword)` and `\(name)`, found `\(actual)`"
+            return "There should be exactly 1 space between `\(keyword)` and `\(name)`, found `\(actualWhitespace(actual))`"
         case .spaceBeforeColon(let actual, let name):
             return "For `\(name)`, there should be no whitespace before `:`, found `\(actual)`"
         case .preDashSpace(let keyword, let actual):
-            return "`\(keyword)` should start with exactly 1 space before `-`, found `\(actual)`"
+            return "`\(keyword)` should start with exactly 1 space before `-`, found `\(actualWhitespace(actual))`"
         case .spaceBetweenDashAndKeyword(let keyword, let actual):
-            return "There should be exactly 1 space between `-` and `\(keyword)`, found `\(actual)`"
+            return "There should be exactly 1 space between `-` and `\(keyword)`, found `\(actualWhitespace(actual))`"
         case .verticalAlignment(let expected, let nameOrKeyword, let line):
             return "Line \(line) of `\(nameOrKeyword)`'s description is not properly vertically aligned (should have \(expected) leading spaces)"
         case .spaceAfterColon(let keyword, let actual):
-            return "For `\(keyword)`, there should be exactly 1 space after `:`, found `\(actual)`"
+            return "For `\(keyword)`, there should be exactly 1 space after `:`, found `\(actualWhitespace(actual))`"
         case .keywordCasingForParameter(let actual, let expected, let name):
             return "For `\(name)`, `\(expected)` is misspelled as `\(actual)`"
         case .keywordCasing(let actual, let expected):

--- a/Sources/Informant/TtyTextFormatter.swift
+++ b/Sources/Informant/TtyTextFormatter.swift
@@ -2,6 +2,10 @@ import Chalk
 import Critic
 
 private extension DocProblem.Detail {
+    private func actualWhitespace(_ actual: String) -> String {
+        actual.isEmpty ? "none" : "\(actual, color: .cyan)"
+    }
+
     private var description: String {
         switch self {
         case .redundantParameter(let name):
@@ -13,21 +17,21 @@ private extension DocProblem.Detail {
         case .missingReturn(let type):
             return "Missing docstring for return type \(type, color: .cyan)"
         case .preDashSpaceInParameter(let expected, let actual, let name):
-            return "Parameter \(name, color: .green) should start with exactly \(String(expected), color: .cyan) space\(expected > 1 ? "s" : "") before \("-", color: .green), found \(actual, background: .cyan)"
+            return "Parameter \(name, color: .green) should start with exactly \(String(expected), color: .cyan) space\(expected > 1 ? "s" : "") before \("-", color: .green), found \(actualWhitespace(actual))"
         case .spaceBetweenDashAndParamaterKeyword(let actual, let keyword, let name):
-            return "\(name, color: .green) should have exactly 1 space between \("-", color: .green) and \(keyword, color: .green), found \(actual, background: .cyan)"
+            return "\(name, color: .green) should have exactly 1 space between \("-", color: .green) and \(keyword, color: .green), found \(actualWhitespace(actual))"
         case .spaceBeforeParameterName(let actual, let keyword, let name):
-            return "There should be exactly 1 space between \(keyword, color: .green) and \(name, color: .green), found \(actual, background: .cyan)"
+            return "There should be exactly 1 space between \(keyword, color: .green) and \(name, color: .green), found \(actualWhitespace(actual))"
         case .spaceBeforeColon(let actual, let name):
             return "For \(name, color: .green), there should be no whitespace before \(":", color: .green), found \(actual, background: .cyan)"
         case .preDashSpace(let keyword, let actual):
-            return "\(keyword, color: .green) should start with exactly 1 space before \("-", color: .green), found \(actual, background: .cyan)"
+            return "\(keyword, color: .green) should start with exactly 1 space before \("-", color: .green), found \(actualWhitespace(actual))"
         case .spaceBetweenDashAndKeyword(let keyword, let actual):
-            return "There should be exactly 1 space between \("-", color: .green) and \(keyword, color: .green), found \(actual, background: .cyan)"
+            return "There should be exactly 1 space between \("-", color: .green) and \(keyword, color: .green), found \(actualWhitespace(actual))"
         case .verticalAlignment(let expected, let nameOrKeyword, let line):
             return "Line \(line, color: .green) of \(nameOrKeyword, color: .green)'s description is not properly vertically aligned (should have \(expected, color: .green) leading spaces)"
         case .spaceAfterColon(let keyword, let actual):
-            return "For \(keyword, color: .green), there should be exactly 1 space after \(":", color: .green), found \(actual, background: .cyan)"
+            return "For \(keyword, color: .green), there should be exactly 1 space after \(":", color: .green), found \(actualWhitespace(actual))"
         case .keywordCasingForParameter(let actual, let expected, let name):
             return "For \(name, color: .green), \(expected, color: .green) is misspelled as \(actual, color: .cyan)"
         case .keywordCasing(let actual, let expected):


### PR DESCRIPTION
When there's no actual whitespace and we need to show users, it's
confusing because in TTY format it'll just print an empty string.

Use the word "none" instead is better.

Closes #42 