### PR TITLE
[Informant] Fix various formatting problems

### DIFF
--- a/Sources/Critic/DocProblem.swift
+++ b/Sources/Critic/DocProblem.swift
@@ -12,7 +12,7 @@ public struct DocProblem {
         case missingParameter(String, String)
         case missingThrow
         case missingReturn(String)
-        case preDashSpaceInParameter(Int, String, String) // Actual, expected, name
+        case preDashSpaceInParameter(Int, String, String) // expected, actual, name
         case spaceBetweenDashAndParamaterKeyword(String, String, String) // Actual, keyword, name
         case spaceBeforeParameterName(String, String, String) // Actual, keyword, name
         case spaceBeforeColon(String, String) // Actual, name

--- a/Sources/Informant/PlainTextFormatter.swift
+++ b/Sources/Informant/PlainTextFormatter.swift
@@ -18,19 +18,19 @@ private extension DocProblem.Detail {
         case .preDashSpaceInParameter(let expected, let actual, let name):
             return "Parameter `\(name)` should start with exactly \(expected) space\(expected > 1 ? "s" : "") before `-`, found `\(actual)`"
         case .spaceBetweenDashAndParamaterKeyword(let actual, let keyword, let name):
-            return "`\(name)` should have exactly 1 space between `-` and `\(keyword)`, found `\(actualWhitespace(actual))`"
+            return "`\(name)` should have exactly 1 space between `-` and `\(keyword)`, found \(actualWhitespace(actual))"
         case .spaceBeforeParameterName(let actual, let keyword, let name):
-            return "There should be exactly 1 space between `\(keyword)` and `\(name)`, found `\(actualWhitespace(actual))`"
+            return "There should be exactly 1 space between `\(keyword)` and `\(name)`, found \(actualWhitespace(actual))"
         case .spaceBeforeColon(let actual, let name):
             return "For `\(name)`, there should be no whitespace before `:`, found `\(actual)`"
         case .preDashSpace(let keyword, let actual):
-            return "`\(keyword)` should start with exactly 1 space before `-`, found `\(actualWhitespace(actual))`"
+            return "`\(keyword)` should start with exactly 1 space before `-`, found \(actualWhitespace(actual))"
         case .spaceBetweenDashAndKeyword(let keyword, let actual):
-            return "There should be exactly 1 space between `-` and `\(keyword)`, found `\(actualWhitespace(actual))`"
+            return "There should be exactly 1 space between `-` and `\(keyword)`, found \(actualWhitespace(actual))"
         case .verticalAlignment(let expected, let nameOrKeyword, let line):
             return "Line \(line) of `\(nameOrKeyword)`'s description is not properly vertically aligned (should have \(expected) leading spaces)"
         case .spaceAfterColon(let keyword, let actual):
-            return "For `\(keyword)`, there should be exactly 1 space after `:`, found `\(actualWhitespace(actual))`"
+            return "For `\(keyword)`, there should be exactly 1 space after `:`, found \(actualWhitespace(actual))"
         case .keywordCasingForParameter(let actual, let expected, let name):
             return "For `\(name)`, `\(expected)` is misspelled as `\(actual)`"
         case .keywordCasing(let actual, let expected):

--- a/Sources/Informant/TtyTextFormatter.swift
+++ b/Sources/Informant/TtyTextFormatter.swift
@@ -3,7 +3,7 @@ import Critic
 
 private extension DocProblem.Detail {
     private func actualWhitespace(_ actual: String) -> String {
-        actual.isEmpty ? "none" : "\(actual, color: .cyan)"
+        actual.isEmpty ? "none" : "\(actual, background: .cyan)"
     }
 
     private var description: String {
@@ -17,7 +17,7 @@ private extension DocProblem.Detail {
         case .missingReturn(let type):
             return "Missing docstring for return type \(type, color: .cyan)"
         case .preDashSpaceInParameter(let expected, let actual, let name):
-            return "Parameter \(name, color: .green) should start with exactly \(String(expected), color: .cyan) space\(expected > 1 ? "s" : "") before \("-", color: .green), found \(actualWhitespace(actual))"
+            return "Parameter \(name, color: .green) should start with exactly \(expected, color: .cyan) space\(expected > 1 ? "s" : "") before \("-", color: .green), found \(actualWhitespace(actual))"
         case .spaceBetweenDashAndParamaterKeyword(let actual, let keyword, let name):
             return "\(name, color: .green) should have exactly 1 space between \("-", color: .green) and \(keyword, color: .green), found \(actualWhitespace(actual))"
         case .spaceBeforeParameterName(let actual, let keyword, let name):


### PR DESCRIPTION
… for whitespace literals.

1. plain format whitespace were double quoted.
2. tty format was mistakenly colored on the foreground.
3. documentation for a problem detail was wrong.