### PR TITLE
Include config file name in excludedYetNoProblemIsFound messaging

### DIFF
--- a/Sources/Critic/DocProblem.swift
+++ b/Sources/Critic/DocProblem.swift
@@ -35,7 +35,7 @@ public struct DocProblem {
         case sectionShouldEndWithEmptyLine(String) // keyword or parameter name
         case redundantKeyword(String) // keyword
         case redundantTextFollowingParameterHeader(String) // keyword
-        case excludedYetNoProblemIsFound
+        case excludedYetNoProblemIsFound(String) // config path
         case excludedYetNotIncluded
         case parametersAreNotGrouped
         case parametersAreNotSeparated

--- a/Sources/DrString/check.swift
+++ b/Sources/DrString/check.swift
@@ -29,7 +29,7 @@ func report(_ problem: DocProblem, format: Configuration.OutputFormat) {
     print("\(output)\n")
 }
 
-public func check(with config: Configuration) -> CheckResult {
+public func check(with config: Configuration, configFile: String) -> CheckResult {
     if config.includedPaths.isEmpty {
         fputs("[check] Paths to source files are missing. Please provide some.\n", stderr)
         return .missingInput
@@ -90,7 +90,7 @@ public func check(with config: Configuration) -> CheckResult {
                             filePath: path,
                             line: 0,
                             column: 0,
-                            details: [.excludedYetNoProblemIsFound]
+                            details: [.excludedYetNoProblemIsFound(configFile)]
                         ),
                         format: config.outputFormat
                     )

--- a/Sources/DrStringCLI/check.swift
+++ b/Sources/DrStringCLI/check.swift
@@ -33,7 +33,7 @@ func check(flags: Flags, arguments: [String], help: String) {
         config = DrString.Configuration(flags)
     }
 
-    switch check(with: config) {
+    switch check(with: config, configFile: path) {
     case .ok:
         return
     case .foundProblems:

--- a/Sources/Informant/PlainTextFormatter.swift
+++ b/Sources/Informant/PlainTextFormatter.swift
@@ -43,8 +43,8 @@ private extension DocProblem.Detail {
             return "Redundant documentation for `\(keyword)`"
         case .redundantTextFollowingParameterHeader(let keyword):
             return "`:` should be the last character on the line for `\(keyword)`"
-        case .excludedYetNoProblemIsFound:
-            return "This file is explicitly excluded, but it has no docstring problems."
+        case .excludedYetNoProblemIsFound(let configFile):
+            return "This file is explicitly excluded in \(configFile), but it has no docstring problems."
         case .excludedYetNotIncluded:
             return "This file is explicitly excluded, but it's not included for checking anyways."
         case .parametersAreNotGrouped:

--- a/Sources/Informant/TtyTextFormatter.swift
+++ b/Sources/Informant/TtyTextFormatter.swift
@@ -44,8 +44,8 @@ private extension DocProblem.Detail {
             return "Redundant documentation for \(keyword, color: .green)"
         case .redundantTextFollowingParameterHeader(let keyword):
             return "\(":", color: .green) should be the last character on the line for \(keyword, color: .green)"
-        case .excludedYetNoProblemIsFound:
-            return "This file is explicitly excluded, but it has no docstring problems (except for this)."
+        case .excludedYetNoProblemIsFound(let configFile):
+            return "This file is explicitly excluded in \(configFile), but it has no docstring problems (except for this)."
         case .excludedYetNotIncluded:
             return "This file is explicitly excluded, but it's not included for checking anyways."
         case .parametersAreNotGrouped:

--- a/Tests/DrStringTests/ProblemCheckingTests.swift
+++ b/Tests/DrStringTests/ProblemCheckingTests.swift
@@ -28,7 +28,8 @@ final class ProblemCheckingTests: XCTestCase {
                 firstKeywordLetter: firstLetter,
                 outputFormat: .plain,
                 separatedSections: needsSeparation,
-                parameterStyle: parameterStyle)
+                parameterStyle: parameterStyle),
+                configFile: ".drstring.toml"
             )
         }
     }

--- a/Tests/DrStringTests/SuperfluousExclusionTests.swift
+++ b/Tests/DrStringTests/SuperfluousExclusionTests.swift
@@ -19,14 +19,15 @@ final class SuperfluousExclusionTests: XCTestCase {
                 firstKeywordLetter: .lowercase,
                 outputFormat: .plain,
                 separatedSections: [],
-                parameterStyle: .whatever)
+                parameterStyle: .whatever),
+                configFile: ".drstring.toml"
             )
         }
     }
 
     func testAllowSuperfluousExclusion() {
         XCTAssert(runTest(
-            expectation: "// CHECK-NOT: This file is explicitly excluded, but it has no docstring problem",
+            expectation: "// CHECK-NOT: This file is explicitly excluded in .drstring.toml, but it has no docstring problem",
             include: ["complete"],
             exclude: ["complete"],
             allowSuperfluousExclusion: true)
@@ -35,7 +36,7 @@ final class SuperfluousExclusionTests: XCTestCase {
 
     func testNoSuperfluousExclusion() {
         XCTAssert(runTest(
-            expectation: "// CHECK-NOT: This file is explicitly excluded, but it has no docstring problem",
+            expectation: "// CHECK-NOT: This file is explicitly excluded .drstring.toml, but it has no docstring problem",
             include: ["badParamFormat"],
             exclude: ["badReturnsFormat"],
             allowSuperfluousExclusion: false)
@@ -44,7 +45,7 @@ final class SuperfluousExclusionTests: XCTestCase {
 
     func testNormalExclusionIsNotSuperfluous() {
         XCTAssert(runTest(
-            expectation: "// CHECK-NOT: This file is explicitly excluded, but it has no docstring problem",
+            expectation: "// CHECK-NOT: This file is explicitly excluded .drstring.toml, but it has no docstring problem",
             include: ["badParamFormat", "badReturnsFormat"],
             exclude: ["badReturnsFormat"],
             allowSuperfluousExclusion: false)
@@ -54,7 +55,7 @@ final class SuperfluousExclusionTests: XCTestCase {
     func testYesSuperfluousExclusion() {
         let expectation = """
         // CHECK: complete.swift
-        // CHECK: This file is explicitly excluded, but it has no docstring problem
+        // CHECK: This file is explicitly excluded in .drstring.toml, but it has no docstring problem
         """
 
         XCTAssert(runTest(
@@ -67,7 +68,7 @@ final class SuperfluousExclusionTests: XCTestCase {
 
     func testSuperfluousExclusionViaGlob() {
         XCTAssert(runTest(
-            expectation: "// CHECK-NOT: This file is explicitly excluded, but it has no docstring problem",
+            expectation: "// CHECK-NOT: This file is explicitly excluded in .drstring.toml, but it has no docstring problem",
             include: ["badParamFormat"],
             exclude: ["*omplete"],
             allowSuperfluousExclusion: false)


### PR DESCRIPTION
This change updates the `excludedYetNoProblemIsFound` message from:

> This file is explicitly excluded, but it has no docstring problems.

to

> This file is explicitly excluded in .drstring.toml, but it has no docstring problems.

Since the config file is a dotfile, it's not uncommon that a grep tool will miss it.