### PR TITLE
[CLI] Implement customizable config path

### DIFF
--- a/Sources/DrStringCLI/Constants.swift
+++ b/Sources/DrStringCLI/Constants.swift
@@ -11,4 +11,5 @@ enum Constants {
     static let parameterStyle = "parameter-style"
     static let alignAfterColon = "align-after-colon"
     static let columnLimit = "column-limit"
+    static let configFile = "config-file"
 }

--- a/Sources/DrStringCLI/Options.swift
+++ b/Sources/DrStringCLI/Options.swift
@@ -55,4 +55,8 @@ enum Options {
         longName: Constants.columnLimit,
         type: Int.self,
         description: "Max number of columns a line can fit, beyond which is problematic.")
+    static let configFile = Flag(
+        longName: Constants.configFile,
+        type: String.self,
+        description: "Path to the configuration TOML file.")
 }

--- a/Sources/DrStringCLI/ParsedOptions.swift
+++ b/Sources/DrStringCLI/ParsedOptions.swift
@@ -3,13 +3,14 @@ import DrString
 import Pathos
 import TOMLDecoder
 
+private let kDefaultConfigurationPath = ".drstring.toml"
 enum ParsedOptions {
     case success(DrString.Configuration, configPath: String?)
     case configDecodeFailure(configPath: String)
 
     init(from flags: Flags, arguments: [String]) {
         let config: DrString.Configuration
-        var path: String? = ".drstring.toml"
+        var path: String? = flags.getString(name: Constants.configFile) ?? kDefaultConfigurationPath
         if let path = path, (try? isA(.file, atPath: path)) == .some(true) {
             guard let configText = try? readString(atPath: path),
                 let decoded = try? TOMLDecoder().decode(DrString.Configuration.self, from: configText) else

--- a/Sources/DrStringCLI/check.swift
+++ b/Sources/DrStringCLI/check.swift
@@ -13,6 +13,7 @@ private let checkFlags = [
     Options.verticalAlign,
     Options.alignAfterColon,
     Options.superfluousExclusion,
+    Options.configFile,
 ]
 
 func check(with options: ParsedOptions, help: String) {

--- a/Sources/DrStringCLI/format.swift
+++ b/Sources/DrStringCLI/format.swift
@@ -21,6 +21,7 @@ private let formatFlags = [
     Options.separations,
     Options.verticalAlign,
     Options.columnLimit,
+    Options.configFile,
 ]
 
 private let longMessage = """


### PR DESCRIPTION
Allow custom config file paths via `--config-file` CLI option.

Closes #52 