### PR TITLE
[Crawler] Treat initializers the same as functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### New
+
+- `init`s are now treated the same as functions. Prior to this release, they were ignored.
+
 ## 0.3.0
 
 ### New

--- a/Sources/Crawler/DocExtractor.swift
+++ b/Sources/Crawler/DocExtractor.swift
@@ -46,4 +46,24 @@ private final class DocExtractor: SyntaxRewriter {
         self.findings.append(finding)
         return node
     }
+
+    override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
+        let location = node.startLocation(converter: self.converter)
+        let parameters = node.parameters.parameterList.map { $0.parameter }
+        let signatureText = "init(\(parameters.reduce("") { $0 + ($1.label ?? $1.name) + ":" }))"
+        let finding = Documentable(
+            path: location.file ?? "",
+            line: (location.line ?? 0) - 1,
+            column: (location.column ?? 0) - 1,
+            name: signatureText,
+            docLines: node.leadingTrivia?.docStringLines ?? [],
+            children: [],
+            details: .function(
+                throws: false,
+                returnType: nil,
+                parameters: parameters)
+        )
+        self.findings.append(finding)
+        return node
+    }
 }

--- a/Tests/DrStringTests/Fixtures/init.fixture
+++ b/Tests/DrStringTests/Fixtures/init.fixture
@@ -1,0 +1,5 @@
+struct InitTest {
+    // CHECK: Missing docstring for `x` of type `Int`
+    /// Description
+    init(_ x: Int) {}
+}

--- a/Tests/DrStringTests/ProblemCheckingTests.swift
+++ b/Tests/DrStringTests/ProblemCheckingTests.swift
@@ -120,4 +120,8 @@ final class ProblemCheckingTests: XCTestCase {
         XCTAssert(runTest(fileName: "alignAfterColonNetRequired",
                           alignAfterColon: [.parameters, .throws, .returns], expectEmpty: true))
     }
+
+    func testInitProblemsAreChecked() throws {
+        XCTAssert(runTest(fileName: "init"))
+    }
 }

--- a/Tests/DrStringTests/XCTestManifests.swift
+++ b/Tests/DrStringTests/XCTestManifests.swift
@@ -27,6 +27,7 @@ extension ProblemCheckingTests {
         ("testGroupedParameterStyle", testGroupedParameterStyle),
         ("testIgnoreReturns", testIgnoreReturns),
         ("testIgnoreThrows", testIgnoreThrows),
+        ("testInitProblemsAreChecked", testInitProblemsAreChecked),
         ("testLowercaseKeywords", testLowercaseKeywords),
         ("testMisalignedParameterDescriptions", testMisalignedParameterDescriptions),
         ("testMissingSectionSeparator", testMissingSectionSeparator),


### PR DESCRIPTION
Closes #92