### PR TITLE
[Informat] Improve output for file-wide problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+- Improved problem description when it's not related to a particular part of code. For example, when a file is
+  superfically excluded (#90).
+
 ## 0.3.0
 
 ### New

--- a/Sources/Informant/PlainTextFormatter.swift
+++ b/Sources/Informant/PlainTextFormatter.swift
@@ -64,7 +64,8 @@ private extension DocProblem {
         let count = self.details.count
         let pluralPostfix = count > 1 ? "s" : ""
         let path = (try? absolutePath(ofPath: self.filePath)) ?? self.filePath
-        let header = "\(path):\(self.line + 1):\(self.column): warning: \(count) docstring problem\(pluralPostfix) regarding `\(self.docName)`"
+        let subjectClause = self.docName.isEmpty ? "" : " regarding `\(self.docName)`"
+        let header = "\(path):\(self.line + 1):\(self.column): warning: \(count) docstring problem\(pluralPostfix)\(subjectClause)"
         return ([header] + self.details.map { $0.fullDescription }).joined(separator: "\n")
     }
 }

--- a/Sources/Informant/TtyTextFormatter.swift
+++ b/Sources/Informant/TtyTextFormatter.swift
@@ -67,7 +67,8 @@ private extension DocProblem {
         let count = self.details.count
         let pluralPostfix = count > 1 ? "s" : ""
         let path = (try? absolutePath(ofPath: self.filePath)) ?? self.filePath
-        let headerText = "\(path):\(self.line + 1):\(self.column): \("warning", color: .yellow): \(count) docstring problem\(pluralPostfix) regarding \(self.docName, color: .green)"
+        let subjectClause = self.docName.isEmpty ? "" : " regarding \(self.docName, color: .green)"
+        let headerText = "\(path):\(self.line + 1):\(self.column): \("warning", color: .yellow): \(count) docstring problem\(pluralPostfix)\(subjectClause)"
         let header = "\(headerText, style: .bold)"
         return ([header] + self.details.map { $0.fullDescription }).joined(separator: "\n")
     }


### PR DESCRIPTION
When a problem is regarding the file itself and not a particular part of
code (superfical exclusion, for example), the message should not include
reference to the code since there's nothing there.

Closes #90