### PR TITLE
Fix bug formatting empty docstring items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Improved
+
+- Fixed bug #127, where docstring item with empty content is incorrectly formatted.
+
 ## 0.3.1
 
 ### Changes

--- a/Sources/Editor/DocString+Formatting.swift
+++ b/Sources/Editor/DocString+Formatting.swift
@@ -40,7 +40,7 @@ extension DocString.Entry {
 
         var result = self.description.enumerated().flatMap { (index, line) -> [String] in
             if line.text.isEmpty {
-                return ["///"]
+                return index > 0 ? ["///"] : [""]
             }
 
             let lead = line.lead.starts(with: " ") ? line.lead : " "
@@ -81,7 +81,11 @@ extension DocString.Entry {
         }
 
         if let firstLineContent = result.first {
-            result[0] = "///\(firstLineHeader)\(firstLineContent)"
+            if firstLineContent.allSatisfy({ $0.isWhitespace }) {
+                result[0] = "///\(firstLineHeader.dropLast())" // remove excessive trailing space
+            } else {
+                result[0] = "///\(firstLineHeader)\(firstLineContent)"
+            }
         }
 
         return result
@@ -110,7 +114,7 @@ extension DocString.Entry {
         let headerReplacement = String(Array(repeating: " ", count: firstLineHeader.count))
         var result = self.description.enumerated().flatMap { (index, line) -> [String] in
             if line.text.isEmpty {
-                return ["///"]
+                return index > 0 ? ["///"] : [""]
             }
 
             let lead = line.lead.starts(with: " ") ? line.lead : " "
@@ -151,7 +155,11 @@ extension DocString.Entry {
         }
 
         if let firstLineContent = result.first {
-            result[0] = "///\(firstLineHeader)\(firstLineContent)"
+            if firstLineContent.allSatisfy({ $0.isWhitespace }) {
+                result[0] = "///\(firstLineHeader.dropLast())" // remove excessive trailing space
+            } else {
+                result[0] = "///\(firstLineHeader)\(firstLineContent)"
+            }
         }
 
         return result

--- a/Tests/DrStringTests/Fixtures/Formatting/emptyitem.fixture
+++ b/Tests/DrStringTests/Fixtures/Formatting/emptyitem.fixture
@@ -1,0 +1,8 @@
+enum init {
+    /// description
+    ///
+    /// - Parameter lineItem:
+    /// - Returns:
+    init(_ lineItem: LineItem) -> Int {
+    }
+}

--- a/Tests/DrStringTests/Fixtures/Formatting/emptyitem_expectation.fixture
+++ b/Tests/DrStringTests/Fixtures/Formatting/emptyitem_expectation.fixture
@@ -1,0 +1,8 @@
+enum init {
+    /// description
+    ///
+    /// - Parameter lineItem:
+    /// - Returns:
+    init(_ lineItem: LineItem) -> Int {
+    }
+}

--- a/Tests/DrStringTests/FormattingTests.swift
+++ b/Tests/DrStringTests/FormattingTests.swift
@@ -76,4 +76,8 @@ final class FormattingTests: XCTestCase {
     func testFormatPatchesFilesProperly2() throws {
         try self.verify(sourceName: "source4", expectationName: "expectation4", file: #file, line: #line)
     }
+
+    func testFormatHandlesEmptyDocstringItemsCorrectly() throws {
+        try self.verify(sourceName: "emptyitem", expectationName: "emptyitem_expectation", file: #file, line: #line)
+    }
 }

--- a/Tests/DrStringTests/XCTestManifests.swift
+++ b/Tests/DrStringTests/XCTestManifests.swift
@@ -6,6 +6,7 @@ extension FormattingTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__FormattingTests = [
+        ("testFormatHandlesEmptyDocstringItemsCorrectly", testFormatHandlesEmptyDocstringItemsCorrectly),
         ("testFormatPatchesFilesProperly0", testFormatPatchesFilesProperly0),
         ("testFormatPatchesFilesProperly1", testFormatPatchesFilesProperly1),
         ("testFormatPatchesFilesProperly2", testFormatPatchesFilesProperly2),


### PR DESCRIPTION
The first line in an item is different than the rest lines in that its
`///` is later added in a different place.

This logic is so messy :/

Fixes #127