### PR TITLE
Record end-line for documentables

### DIFF
--- a/Sources/Crawler/DocExtractor.swift
+++ b/Sources/Crawler/DocExtractor.swift
@@ -2,8 +2,10 @@ import Pathos
 import SwiftSyntax
 
 public func extractDocs(fromSourcePath sourcePath: String) throws -> ([Documentable], String) {
-    let extractor = try DocExtractor(filePath: sourcePath)
-    return (try extractor.extractDocs(), extractor.source)
+    let sourceText = try readString(atPath: sourcePath)
+    let extractor = try DocExtractor(sourceText: sourceText, sourcePath: sourcePath)
+
+    return (try extractor.extractDocs(), sourceText)
 }
 
 private final class DocExtractor: SyntaxRewriter {
@@ -11,14 +13,10 @@ private final class DocExtractor: SyntaxRewriter {
     private let syntax: SourceFileSyntax
     private let converter: SourceLocationConverter
 
-    let source: String
-
-    init(filePath: String) throws {
-        let sourceText = try readString(atPath: filePath)
-        self.source = sourceText
+    init(sourceText: String, sourcePath: String?) throws {
         let tree = try SyntaxParser.parse(source: sourceText)
         self.syntax = tree
-        self.converter = SourceLocationConverter(file: filePath, source: sourceText)
+        self.converter = SourceLocationConverter(file: sourcePath ?? "", source: sourceText)
     }
 
     func extractDocs() throws -> [Documentable] {
@@ -28,13 +26,15 @@ private final class DocExtractor: SyntaxRewriter {
 
     override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
         let location = node.startLocation(converter: self.converter)
+        let endLocation = node.endLocation(converter: self.converter)
         let parameters = node.parameters
         let signatureText = node.identifier.description
             + "(\(parameters.reduce("") { $0 + ($1.label ?? $1.name) + ":" }))"
         let finding = Documentable(
             path: location.file ?? "",
-            line: (location.line ?? 0) - 1,
-            column: (location.column ?? 0) - 1,
+            startLine: (location.line ?? 0) - 1,
+            startColumn: (location.column ?? 0) - 1,
+            endLine: (endLocation.line ?? 0) - 1,
             name: signatureText,
             docLines: node.leadingTrivia?.docStringLines ?? [],
             children: [],
@@ -49,12 +49,14 @@ private final class DocExtractor: SyntaxRewriter {
 
     override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
         let location = node.startLocation(converter: self.converter)
+        let endLocation = node.endLocation(converter: self.converter)
         let parameters = node.parameters.parameterList.map { $0.parameter }
         let signatureText = "init(\(parameters.reduce("") { $0 + ($1.label ?? $1.name) + ":" }))"
         let finding = Documentable(
             path: location.file ?? "",
-            line: (location.line ?? 0) - 1,
-            column: (location.column ?? 0) - 1,
+            startLine: (location.line ?? 0) - 1,
+            startColumn: (location.column ?? 0) - 1,
+            endLine: (endLocation.line ?? 0) - 1,
             name: signatureText,
             docLines: node.leadingTrivia?.docStringLines ?? [],
             children: [],

--- a/Sources/Crawler/Documentable.swift
+++ b/Sources/Crawler/Documentable.swift
@@ -15,8 +15,9 @@ public struct EnumCase: Equatable {
 
 public struct Documentable: Equatable {
     public let path: String
-    public let line: Int
-    public let column: Int
+    public let startLine: Int
+    public let startColumn: Int
+    public let endLine: Int
     public let name: String
     public let docLines: [String]
     public let children: [Documentable]

--- a/Sources/Critic/Validating.swift
+++ b/Sources/Critic/Validating.swift
@@ -34,8 +34,8 @@ extension Documentable {
             return DocProblem(
                 docName: self.name,
                 filePath: self.path,
-                line: self.line,
-                column: self.column,
+                line: self.startLine,
+                column: self.startColumn,
                 details: details
             )
         default:

--- a/Sources/Editor/Documentable+Editing.swift
+++ b/Sources/Editor/Documentable+Editing.swift
@@ -18,7 +18,7 @@ extension Documentable {
         }
 
         let formatted = docs.reformat(
-            initialColumn: self.column,
+            initialColumn: self.startColumn,
             columnLimit: columnLimit,
             verticalAlign: verticalAlign,
             alignAfterColon: alignAfterColon,
@@ -27,11 +27,11 @@ extension Documentable {
             separations: separations)
 
         if formatted != self.docLines {
-            let padding = String(Array(repeating: " ", count: self.column))
+            let padding = String(Array(repeating: " ", count: self.startColumn))
             return [
                 Edit(
-                    startingLine: self.line - self.docLines.count,
-                    endingLine: self.line,
+                    startingLine: self.startLine - self.docLines.count,
+                    endingLine: self.startLine,
                     text: formatted.map { padding + $0 })
             ]
         } else {


### PR DESCRIPTION
This will come in handy when we request documentation check/format for
a particular segment, given a location within it.

|  | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| before | 3.765 ± 0.032 | 3.713 | 3.823 | 1.00 ± 0.01 |
| after  | 3.747 ± 0.026 | 3.720 | 3.813 | 1.00 |