### PR TITLE
[Crawler] Detect throws for `init`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   configuration cause options from command-line to be completely ignored. Now, the command-line options take
   precedence over config file.
 
+- Fixed bug #140, where `throws` for `init`s were ignored when extracting code signature.
+
 ### New
 
 - Docstring entries that does not contain a `:` in their header (for example, `- parameter:`) were previously

--- a/Sources/Crawler/DocExtractor.swift
+++ b/Sources/Crawler/DocExtractor.swift
@@ -61,7 +61,7 @@ private final class DocExtractor: SyntaxRewriter {
             docLines: node.leadingTrivia?.docStringLines ?? [],
             children: [],
             details: .function(
-                throws: false,
+                throws: node.throws,
                 returnType: nil,
                 parameters: parameters)
         )

--- a/Sources/Crawler/SwiftSyntax+Extensions.swift
+++ b/Sources/Crawler/SwiftSyntax+Extensions.swift
@@ -30,6 +30,12 @@ extension FunctionDeclSyntax {
     }
 }
 
+extension InitializerDeclSyntax {
+    var `throws`: Bool {
+        return self.throwsOrRethrowsKeyword != nil
+    }
+}
+
 extension Trivia {
     var docStringLines: [String] {
         var result = [String]()

--- a/Tests/DrStringTests/Fixtures/140.fixture
+++ b/Tests/DrStringTests/Fixtures/140.fixture
@@ -1,0 +1,10 @@
+// CHECK-NOT: Redundant documentation for `throws`
+/// An executable value that can identify issues (violations) in Swift source code.
+public protocol Rule {
+    /// Creates a rule by applying its configuration.
+    ///
+    /// - parameter configuration: The untyped configuration value to apply.
+    ///
+    /// - throws: Throws if the configuration didn't match the expected format.
+    init(configuration: Any) throws
+}

--- a/Tests/DrStringTests/ProblemCheckingTests.swift
+++ b/Tests/DrStringTests/ProblemCheckingTests.swift
@@ -121,4 +121,8 @@ final class ProblemCheckingTests: XCTestCase {
     func testInitProblemsAreChecked() throws {
         XCTAssert(runTest(fileName: "init"))
     }
+
+    func testInitThrowsIsNotRedundant() throws {
+        XCTAssert(runTest(fileName: "140", ignoreThrows: true))
+    }
 }

--- a/Tests/DrStringTests/XCTestManifests.swift
+++ b/Tests/DrStringTests/XCTestManifests.swift
@@ -41,6 +41,7 @@ extension ProblemCheckingTests {
         ("testIgnoreReturns", testIgnoreReturns),
         ("testIgnoreThrows", testIgnoreThrows),
         ("testInitProblemsAreChecked", testInitProblemsAreChecked),
+        ("testInitThrowsIsNotRedundant", testInitThrowsIsNotRedundant),
         ("testLowercaseKeywords", testLowercaseKeywords),
         ("testMisalignedParameterDescriptions", testMisalignedParameterDescriptions),
         ("testMissingSectionSeparator", testMissingSectionSeparator),


### PR DESCRIPTION
This was hard-coded to be `false` previously.

Fixes #140 