### PR TITLE
[Critic] Ignore empty entry descriptions

### DIFF
--- a/Sources/Critic/Validating.swift
+++ b/Sources/Critic/Validating.swift
@@ -102,7 +102,7 @@ func findReturnsProblems(ignoreReturns: Bool, _ docs: DocString, returnType: Str
         let standardPaddingLength = 12
         let standardPadding = String(Array(repeating: " ", count: standardPaddingLength))
         for (index, line) in returnsDoc.description.dropFirst().enumerated() {
-            if line.lead < standardPadding {
+            if line.lead < standardPadding && !(line.lead.isEmpty && line.text.isEmpty) {
                 result.append(.verticalAlignment(standardPaddingLength, keywordText, index + 2))
             }
         }
@@ -159,7 +159,7 @@ func findThrowsProblems(ignoreThrows: Bool, doesThrow: Bool, _ docs: DocString, 
         let standardPaddingLength = 11
         let standardPadding = String(Array(repeating: " ", count: standardPaddingLength))
         for (index, line) in throwsDoc.description.dropFirst().enumerated() {
-            if line.lead < standardPadding {
+            if line.lead < standardPadding && !(line.lead.isEmpty && line.text.isEmpty) {
                 result.append(.verticalAlignment(standardPaddingLength, keywordText, index + 2))
             }
         }

--- a/Tests/DrStringTests/Fixtures/147.fixture
+++ b/Tests/DrStringTests/Fixtures/147.fixture
@@ -1,0 +1,11 @@
+// CHECK-NOT: not properly vertically aligned
+/// Check whether the entire input sequence can be matched against the regular expression.
+///
+/// - Parameter regex: The regular expression to match against.
+///
+/// - Throws: If the regex cannot be created with the given pattern.
+///
+/// - Returns: True if str can be matched entirely against regex.
+public func matchesEntirely(_ regex: String) throws -> Bool {
+    return true
+}

--- a/Tests/DrStringTests/ProblemCheckingTests.swift
+++ b/Tests/DrStringTests/ProblemCheckingTests.swift
@@ -125,4 +125,8 @@ final class ProblemCheckingTests: XCTestCase {
     func testInitThrowsIsNotRedundant() throws {
         XCTAssert(runTest(fileName: "140", ignoreThrows: true))
     }
+
+    func testSeparateLineInThrowsIsNotTreatedAsContinuedBody() throws {
+        XCTAssert(runTest(fileName: "147", alignAfterColon: [.throws], expectEmpty: true))
+    }
 }

--- a/Tests/DrStringTests/XCTestManifests.swift
+++ b/Tests/DrStringTests/XCTestManifests.swift
@@ -49,6 +49,7 @@ extension ProblemCheckingTests {
         ("testNoDocNoError", testNoDocNoError),
         ("testRedundantKeywords", testRedundantKeywords),
         ("testRedundantKeywordsPathsOnly", testRedundantKeywordsPathsOnly),
+        ("testSeparateLineInThrowsIsNotTreatedAsContinuedBody", testSeparateLineInThrowsIsNotTreatedAsContinuedBody),
         ("testSeparateParameterStyle", testSeparateParameterStyle),
         ("testUppercaseKeywords", testUppercaseKeywords),
         ("testWhateverParameterStyle", testWhateverParameterStyle),


### PR DESCRIPTION
This should exist without being a indentation problem.

Closes #147.