### PR TITLE
[CLI] Attempt to find a config file

### DIFF
--- a/Sources/DrString/Command+Receiving.swift
+++ b/Sources/DrString/Command+Receiving.swift
@@ -3,6 +3,24 @@ import TOMLDecoder
 import TSCUtility
 
 private let kDefaultConfigurationPath = ".drstring.toml"
+
+func seekConfigFile(forPath path: String) -> String {
+    guard var dir = try? absolutePath(ofPath: path) else {
+        return kDefaultConfigurationPath
+    }
+
+    while dir != "/" {
+        dir = directory(ofPath: dir)
+        if case let path = join(paths: dir, kDefaultConfigurationPath),
+            (try? isA(.file, atPath: path)) == .some(true)
+        {
+            return path
+        }
+    }
+
+    return kDefaultConfigurationPath
+}
+
 extension Command {
     enum ReceivingError: Error {
         case configFileDoesNotExist(String)
@@ -17,12 +35,12 @@ extension Command {
         try binder.fill(parseResult: result, into: &command)
 
         let explicitPath: String? = try? result.get("--config-file")
-        let configPath = explicitPath ?? kDefaultConfigurationPath
-
-        if explicitPath != nil && (try? isA(.file, atPath: configPath)) != .some(true) {
-            throw ReceivingError.configFileDoesNotExist(configPath)
+        if let explicitPath = explicitPath, (try? isA(.file, atPath: explicitPath)) != .some(true) {
+            throw ReceivingError.configFileDoesNotExist(explicitPath)
         }
 
+        let exampleInput = command.config?.includedPaths.first { !$0.contains("*") }
+        let configPath = explicitPath ?? seekConfigFile(forPath: exampleInput ?? ".")
 
         if let configText = try? readString(atPath: configPath),
             let decoded = try? TOMLDecoder().decode(Configuration.self, from: configText)


### PR DESCRIPTION
If a config file is not explicitly specified via command line argument,
take the first non-glob input file path and walk up to system root. At
each level, look for a `.drstring.toml`. If one is found, use it as
config.