### PR TITLE
Update Pathos to 0.2.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/dduan/Pathos.git",
         "state": {
           "branch": null,
-          "revision": "72e74fa8bf504427d0534d104fe38ccf8855e247",
-          "version": "0.2.1"
+          "revision": "1c87529ebec5243004bbb86caa4247fd5eb6b051",
+          "version": "0.2.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/dduan/Pathos.git",
-            .exact("0.2.1")
+            .exact("0.2.2")
         ),
         .package(
             url: "https://github.com/dduan/TOMLDecoder.git",


### PR DESCRIPTION
It removes a warning from Swift 5.2