### PR TITLE
Update ArgumentParser to 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master
 
+### Changes
+
+The `version` subcommand is replaced by a flag on the main command. So `drstring --version` instead of
+`drstring version`.
+
+
 ## 0.4.0
 
 ### Changes

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "35b76bf577d3cc74820f8991894ce3bcdf024ddc",
-          "version": "0.0.2"
+          "revision": "9f04d1ff1afbccd02279338a2c91e5f27c45e93a",
+          "version": "0.0.5"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/apple/swift-argument-parser",
-            .exact("0.0.2")
+            .exact("0.0.5")
         ),
 
         // For testing

--- a/Sources/DrString/Command.swift
+++ b/Sources/DrString/Command.swift
@@ -2,7 +2,6 @@ public enum Command {
     case check(configFile: String?, config: Configuration)
     case format(Configuration)
     case explain([String])
-    case version
 
     var config: Configuration? {
         switch self {
@@ -10,7 +9,7 @@ public enum Command {
             return config
         case .format(let config):
             return config
-        default:
+        case .explain:
             return nil
         }
     }

--- a/Sources/DrString/execute.swift
+++ b/Sources/DrString/execute.swift
@@ -1,7 +1,3 @@
-func printVersion() {
-    print(version)
-}
-
 public func execute(_ command: Command) throws {
     switch command {
     case .check(let configFile, let config):
@@ -10,7 +6,5 @@ public func execute(_ command: Command) throws {
         try format(with: config)
     case .explain(let problemIDs):
         try explain(problemIDs)
-    case .version:
-        printVersion()
     }
 }

--- a/Sources/DrString/interface.swift
+++ b/Sources/DrString/interface.swift
@@ -81,17 +81,13 @@ struct Main: ParsableCommand {
 
             drstring format --config-file path/to/.drstring.toml
         """,
+        version: version,
         subcommands: [
             Check.self,
             Explain.self,
             Format.self,
-            Version.self,
         ]
     )
-}
-
-struct Version: ParsableCommand {
-    static var configuration = CommandConfiguration(abstract: "Show version.")
 }
 
 extension Configuration.OutputFormat: ExpressibleByArgument {}

--- a/Sources/DrString/run.swift
+++ b/Sources/DrString/run.swift
@@ -58,8 +58,6 @@ extension Command {
             self = .format(config)
         case let command as Explain:
             self = .explain(command.problemID)
-        case _ where command is Version:
-            self = .version
         default:
             return nil
         }


### PR DESCRIPTION
Use the built-in version support from Swift ArgumentParser: https://github.com/apple/swift-argument-parser/pull/102