### PR TITLE
Expose underlying error for invalid TOML config

### DIFF
--- a/Sources/DrString/RecevingError.swift
+++ b/Sources/DrString/RecevingError.swift
@@ -2,14 +2,14 @@ import Foundation
 
 enum ConfigFileError: Error, LocalizedError {
     case configFileDoesNotExist(String)
-    case configFileIsInvalid(String)
+    case configFileIsInvalid(path: String, underlyingError: Error)
 
     var errorDescription: String? {
         switch self {
         case .configFileDoesNotExist(let path):
             return "Could not find configuration file '\(path)'."
-        case .configFileIsInvalid(let path):
-            return "File '\(path)' doesn't contain valid configuration for DrString."
+        case .configFileIsInvalid(let path, let error):
+            return "File '\(path)' doesn't contain valid configuration for DrString. Underlying error: \(error)"
         }
     }
 }

--- a/Sources/DrString/run.swift
+++ b/Sources/DrString/run.swift
@@ -15,16 +15,18 @@ private func makeConfig(from options: SharedCommandLineOptions) throws -> (Strin
     var configPathResult: String?
     config.extend(with: options)
 
-    do {
-        let configText = try readString(atPath: configPath)
-        let decoded = try TOMLDecoder().decode(Configuration.self, from: configText)
-        config = decoded
-        configPathResult = configPath
-        config.extend(with: options)
-        return (configPathResult, config)
-    } catch let error {
-        throw ConfigFileError.configFileIsInvalid(path: configPath, underlyingError: error)
+    if let configText = try? readString(atPath: configPath) {
+        do {
+            let decoded = try TOMLDecoder().decode(Configuration.self, from: configText)
+            config = decoded
+            configPathResult = configPath
+            config.extend(with: options)
+        } catch let error {
+            throw ConfigFileError.configFileIsInvalid(path: configPath, underlyingError: error)
+        }
     }
+
+    return (configPathResult, config)
 }
 
 private let kDefaultConfigurationPath = ".drstring.toml"

--- a/Sources/DrString/run.swift
+++ b/Sources/DrString/run.swift
@@ -15,16 +15,16 @@ private func makeConfig(from options: SharedCommandLineOptions) throws -> (Strin
     var configPathResult: String?
     config.extend(with: options)
 
-    if let configText = try? readString(atPath: configPath),
-    let decoded = try? TOMLDecoder().decode(Configuration.self, from: configText) {
+    do {
+        let configText = try readString(atPath: configPath)
+        let decoded = try TOMLDecoder().decode(Configuration.self, from: configText)
         config = decoded
         configPathResult = configPath
         config.extend(with: options)
-    } else if explicitPath != nil {
-        throw ConfigFileError.configFileIsInvalid(configPath)
+        return (configPathResult, config)
+    } catch let error {
+        throw ConfigFileError.configFileIsInvalid(path: configPath, underlyingError: error)
     }
-
-    return (configPathResult, config)
 }
 
 private let kDefaultConfigurationPath = ".drstring.toml"


### PR DESCRIPTION
This is better than silent failures. The underlying errors are described
by the underlying libraries that generate them. So they need to be
improved else where.

Closes #183.