### PR TITLE
Handle parameter entry with keyword `parameters`

### DIFF
--- a/Sources/Decipher/LineParsing.swift
+++ b/Sources/Decipher/LineParsing.swift
@@ -201,7 +201,12 @@ func parseThrows(fromLine line: String) throws -> (String, TextLeadByWhitespace,
 
 func parse(line: String) throws -> Parsing.LineResult {
     if let (preDash, keyword, preColon, hasColon, description) = try parseGroupedParametersHeader(fromLine: line) {
-        return .groupedParametersHeader(preDash, keyword, preColon, hasColon, description)
+        if preColon.allSatisfy({ $0.isWhitespace }) {
+            return .groupedParametersHeader(preDash, keyword, preColon, hasColon, description)
+        } else if let (preDash, keyword, name, preColon, hasColon, description) = try parseParameter(fromLine: line) {
+            // in case of `- paramaters blah: ...`, we proceed to parse it as a parameter entry
+            return .parameter(preDash, keyword, name, preColon, hasColon, description)
+        }
     } else if let (preDash, keyword, preColon, hasColon, description) = try parseReturns(fromLine: line) {
         return .returns(preDash, keyword, preColon, hasColon, description)
     } else if let (preDash, keyword, preColon, hasColon, description) = try parseThrows(fromLine: line) {

--- a/Tests/DrStringTests/Fixtures/Formatting/expectation192.fixture
+++ b/Tests/DrStringTests/Fixtures/Formatting/expectation192.fixture
@@ -1,0 +1,7 @@
+/// This method will transform any types that are generic
+///
+/// - Parameter type:            The type to normalize
+/// - Parameter replaceSelfWith: If type == "Self"/"Self?"/"Optional<Self>" will return this value
+///                               instead
+/// - Parameter stripInOut:      Whether or not to strip the inout keyword from the type name
+func storedParamType(from type: String, replaceSelfWith: String? = nil, stripInOut: Bool = true) -> String {}

--- a/Tests/DrStringTests/Fixtures/Formatting/source192.fixture
+++ b/Tests/DrStringTests/Fixtures/Formatting/source192.fixture
@@ -1,0 +1,7 @@
+/// This method will transform any types that are generic
+///
+/// - Parameters type:            The type to normalize
+/// - Parameters replaceSelfWith: If type == "Self"/"Self?"/"Optional<Self>" will return this value
+///                               instead
+/// - Parameters stripInOut:      Whether or not to strip the inout keyword from the type name
+func storedParamType(from type: String, replaceSelfWith: String? = nil, stripInOut: Bool = true) -> String {}

--- a/Tests/DrStringTests/FormattingTests.swift
+++ b/Tests/DrStringTests/FormattingTests.swift
@@ -68,4 +68,8 @@ final class FormattingTests: XCTestCase {
     func testFormatHandlesEmptyDocstringItemsCorrectly() throws {
         try self.verify(sourceName: "emptyitem", expectationName: "emptyitem_expectation", file: #file, line: #line)
     }
+
+    func testBug192() throws {
+        try self.verify(sourceName: "source192", expectationName: "expectation192", file: #file, line: #line)
+    }
 }

--- a/Tests/DrStringTests/XCTestManifests.swift
+++ b/Tests/DrStringTests/XCTestManifests.swift
@@ -21,6 +21,7 @@ extension FormattingTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__FormattingTests = [
+        ("testBug192", testBug192),
         ("testFormatHandlesEmptyDocstringItemsCorrectly", testFormatHandlesEmptyDocstringItemsCorrectly),
         ("testFormatPatchesFilesProperly0", testFormatPatchesFilesProperly0),
         ("testFormatPatchesFilesProperly1", testFormatPatchesFilesProperly1),


### PR DESCRIPTION
If a parameter entry is mistakenly prefixed with `- parameters`,
previously we'd see it as a multi-parameter header. Before we proceed to
assign the line to that state, take a look at characters before `:` and
after the keyword. Only proceed as parameter header if there's only
whitespace. Otherwise, try parsing the line again as a parameter entry.

Closes #192.