### PR TITLE
Enable make generate on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,8 @@ test:
 
 .PHONY: test-generated-artifacts
 test-generated-artifacts:
-ifeq ($(shell uname),Darwin)
 	@$(MAKE) generate
 	@git diff --exit-code
-else
-	@echo "Only works on macOS"
-endif
 
 .PHONY: build
 build:


### PR DESCRIPTION
This was disabled because of test discovery