### PR TITLE
Remove duplicate and unnecessary flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/bash
 
 ifeq ($(shell uname),Darwin)
-EXTRA_SWIFT_FLAGS = --arch arm64 --arch x86_64 --disable-sandbox -Xlinker -dead_strip -Xlinker -dead_strip_dylibs
+EXTRA_SWIFT_FLAGS = --arch arm64 --arch x86_64 --disable-sandbox -Xlinker -dead_strip
 else
 SWIFT_TOOLCHAIN = $(shell dirname $(shell ./Scripts/locateswift.sh))
 EXTRA_SWIFT_FLAGS = -Xswiftc -static-stdlib -Xlinker -fuse-ld=lld -Xlinker -L${SWIFT_TOOLCHAIN}/swift/linux -Xlinker -rpath -Xlinker '$$ORIGIN/../lib'
@@ -22,7 +22,7 @@ test-generated-artifacts:
 
 .PHONY: build
 build:
-	@swift build --configuration release -Xswiftc -warnings-as-errors ${EXTRA_SWIFT_FLAGS} --arch arm64 --arch x86_64
+	@swift build --configuration release -Xswiftc -warnings-as-errors ${EXTRA_SWIFT_FLAGS}
 
 .PHONY: generate
 generate: generate-explainers generate-completion-scripts


### PR DESCRIPTION
I added the arch flags twice, and now that we don't use the internal
dylib we don't need -dead_strip_dylibs
